### PR TITLE
remove statics libs not needed after the build

### DIFF
--- a/configs/components/cleanup.rb
+++ b/configs/components/cleanup.rb
@@ -16,6 +16,7 @@ component 'cleanup' do |pkg, settings, _platform|
   cleanup_steps << "#{rm} -rf #{settings[:prefix]}/ssl"
   cleanup_steps << "#{rm} -rf #{settings[:prefix]}/usr/local"
   cleanup_steps << "#{rm} -rf #{settings[:prefix]}/CMake"
+  cleanup_steps << "#{rm} -rf #{settings[:libdir]}/*.{la,a}"
 
   if platform.is_windows?
     %w[


### PR DESCRIPTION
Statics libs are keep in the build and are not necessary after it. As the .a archive format contain headers informations like the time when they are made, it broke the possibility to have reproducible build.

I have put the deletion in the cleanup.rb and not directly in the build process because they are used during the boost compilation.