### PR TITLE
Changes for OpenVox Windows builds

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -39,12 +39,15 @@ component 'cpp-hocon' do |pkg, settings, platform|
       special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
     end
   elsif platform.is_windows?
-    make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment 'PATH', "$(shell cygpath -u #{settings[:prefix]}/lib):$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    make = "/usr/bin/make"
+    pkg.environment 'PATH', "/usr/bin:$(shell cygpath -u #{settings[:prefix]}/lib):$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment 'CYGWIN', settings[:cygwin]
 
-    cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
-    toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+    cmake = '/usr/bin/cmake'
+    toolchain = ""
+    special_flags = "-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++"
+    pkg.environment 'CC', "x86_64-w64-mingw32-gcc"
+    pkg.environment 'CXX', "x86_64-w64-mingw32-g++"
   elsif platform.name =~ /el-6|redhatfips-7|sles-1[12]/
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'
@@ -66,10 +69,9 @@ component 'cpp-hocon' do |pkg, settings, platform|
             end
   end
 
-  cmake_cxx_compiler = ''
   if platform.name =~ /el-7/
     pkg.environment 'PATH', '/opt/rh/devtoolset-7/root/usr/bin:$(PATH)'
-    cmake_cxx_compiler = '-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/g++'
+    special_flags += ' -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/g++'
   end
 
   # Until we build our own gettext packages, disable using locales.
@@ -92,7 +94,6 @@ component 'cpp-hocon' do |pkg, settings, platform|
         #{special_flags} \
         #{boost_static_flag} \
         -DBoost_NO_BOOST_CMAKE=ON \
-        #{cmake_cxx_compiler} \
         ."]
   end
 

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -54,11 +54,15 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
       toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     end
   elsif platform.is_windows?
-    make = "#{settings[:gcc_root]}/bin/mingw32-make"
+    make = "/usr/bin/make"
+    pkg.environment 'PATH', "/usr/bin:$(shell cygpath -u #{settings[:prefix]}/lib):$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment 'CYGWIN', settings[:cygwin]
 
-    cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
-    toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+    cmake = '/usr/bin/cmake'
+    toolchain = ""
+    special_flags = "-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++"
+    pkg.environment 'CC', "x86_64-w64-mingw32-gcc"
+    pkg.environment 'CXX', "x86_64-w64-mingw32-g++"
   elsif platform.name == 'sles-11-x86_64'
     cmake = 'env LD_LIBRARY_PATH=/opt/pl-build-tools/lib64 /opt/pl-build-tools/bin/cmake'
     special_flags = " -DCMAKE_CXX_FLAGS='-Wno-error=implicit-fallthrough -Wno-error=catch-value' "
@@ -78,10 +82,9 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
             end
   end
 
-  cmake_cxx_compiler = ''
   if platform.name =~ /el-7/
     pkg.environment 'PATH', '/opt/rh/devtoolset-7/root/usr/bin:$(PATH)'
-    cmake_cxx_compiler = '-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/g++'
+    special_flags += ' -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/g++'
   end
 
   # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
@@ -106,7 +109,6 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
           -DBoost_NO_BOOST_CMAKE=ON \
           #{special_flags} \
           #{boost_static_flag} \
-          #{cmake_cxx_compiler} \
           ."
     ]
   end

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -1,15 +1,22 @@
 component 'nssm' do |pkg, settings, platform|
-  pkg.load_from_json('configs/components/nssm.json')
+  #pkg.load_from_json('configs/components/nssm.json')
 
-  build_arch = platform.architecture == 'x64' ? 'x64' : 'Win32'
-  platform_toolset = 'v141'
-  target_platform_version = '8.1'
+  # Rather than build this ourselves every time, we use a precompiled binary, since this
+  # binary hasn't changed in the last 5 years. Leaving the code here in case we need to
+  # make changes and recompile it.
 
-  pkg.install do
-    [
-      "#{settings[:msbuild]} nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=.\\\\out\\\\ /p:Platform=#{build_arch} /p:PlatformToolset=#{platform_toolset} /p:TargetPlatformVersion=#{target_platform_version}"
-    ]
-  end
+  #build_arch = platform.architecture == 'x64' ? 'x64' : 'Win32'
+  #platform_toolset = 'v141'
+  #target_platform_version = '8.1'
 
-  pkg.install_file 'out/nssm.exe', "#{settings[:bindir]}/nssm-pxp-agent.exe"
+  #pkg.install do
+  #  [
+  #    "#{settings[:msbuild]} nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=.\\\\out\\\\ /p:Platform=#{build_arch} /p:PlatformToolset=#{platform_toolset} /p:TargetPlatformVersion=#{target_platform_version}"
+  #  ]
+  #end
+
+  #pkg.install_file 'out/nssm.exe', "#{settings[:bindir]}/nssm-pxp-agent.exe"
+  pkg.md5sum '06056fd7f5226410c564ce19b87020c8'
+  pkg.url 'https://artifacts.overlookinfratech.com/components/nssm-pxp-agent.exe'
+  pkg.install_file 'nssm-pxp-agent.exe', "#{settings[:bindir]}/nssm-pxp-agent.exe"
 end

--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"location":"https://s3.osuosl.org/openvox-artifacts/puppet-runtime/202502261/","version":"202502261"}
+{"location":"file:///cygdrive/z/windows-agent-runtime","version":"202502261.3.g6c44bd1a7"}

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -6,7 +6,7 @@ component 'pxp-agent' do |pkg, settings, platform|
   boost_static_flag = ''
 
   if platform.is_windows?
-    pkg.environment 'PATH', "$(shell cygpath -u #{settings[:prefix]}/lib):$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment 'PATH', "/usr/bin:$(shell cygpath -u #{settings[:prefix]}/lib):$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   elsif platform.is_aix?
     pkg.environment 'PATH', '/opt/freeware/bin:$(PATH)'
   else
@@ -67,12 +67,14 @@ component 'pxp-agent' do |pkg, settings, platform|
                        end
     end
   elsif platform.is_windows?
-    make = "#{settings[:gcc_bindir]}/mingw32-make"
+    make = "/usr/bin/make"
     pkg.environment 'CYGWIN', settings[:cygwin]
 
-    cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
-    toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-
+    cmake = '/usr/bin/cmake'
+    toolchain = ""
+    special_flags = "-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++"
+    pkg.environment 'CC', "x86_64-w64-mingw32-gcc"
+    pkg.environment 'CXX', "x86_64-w64-mingw32-g++"
   elsif platform.name =~ /el-6|redhatfips-7|sles-12/
     # use default that is pl-build-tools
   elsif platform.name =~ /sles-11/
@@ -89,10 +91,9 @@ component 'pxp-agent' do |pkg, settings, platform|
             end
   end
 
-  cmake_cxx_compiler = ''
   if platform.name =~ /el-7/
     pkg.environment 'PATH', '/opt/rh/devtoolset-7/root/usr/bin:$(PATH)'
-    cmake_cxx_compiler = '-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/g++'
+    special_flags += ' -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/g++'
   end
 
   # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
@@ -116,7 +117,6 @@ component 'pxp-agent' do |pkg, settings, platform|
           #{special_flags} \
           #{boost_static_flag} \
           -DBoost_NO_BOOST_CMAKE=ON \
-          #{cmake_cxx_compiler} \
           ."
     ]
   end

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -7,11 +7,6 @@ component 'runtime' do |pkg, _settings, platform|
       pkg.build_requires "pl-gcc-#{platform.architecture}"
       pkg.build_requires "pl-binutils-#{platform.architecture}"
     end
-  elsif platform.is_windows?
-    pkg.build_requires "pl-gdbm-#{platform.architecture}"
-    pkg.build_requires "pl-iconv-#{platform.architecture}"
-    pkg.build_requires "pl-libffi-#{platform.architecture}"
-    pkg.build_requires "pl-pdcurses-#{platform.architecture}"
   elsif platform.name == 'sles-11-x86_64'
     pkg.build_requires 'pl-gcc8'
   elsif platform.name =~ /el-6|redhatfips-7|sles-12/

--- a/configs/platforms/windows-2019-x64.rb
+++ b/configs/platforms/windows-2019-x64.rb
@@ -1,0 +1,51 @@
+platform 'windows-2019-x64' do |plat|
+  plat.vmpooler_template 'win-2019-x86_64'
+  plat.servicetype 'windows'
+
+  # Install ruby, ruby-devel, gcc-core, make, git, and libyaml-devel in Cygwin on the Windows image.
+  # Run setup.bat found in the root of this repo. These are needed in order to successfully
+  # do a bundle install. They are included here just in case they get removed somehow.
+  # Make sure "setup-x86_64.exe" (Cygwin's installer) is at the root of C:/
+  packages = [
+    'autoconf',
+    'cmake',
+    'gcc-core',
+    'gcc-g++',
+    'git',
+    'libyaml-devel',
+    'make',
+    'mingw64-x86_64-gcc-core',
+    'mingw64-x86_64-gcc-g++',
+    'mingw64-x86_64-gdbm',
+    'mingw64-x86_64-libffi',
+    'mingw64-x86_64-readline',
+    'mingw64-x86_64-zlib',
+    'ruby',
+    'ruby-devel',
+    'patch',
+    'zlib',
+    'zlib-devel'
+  ]
+
+  plat.provision_with("C:/setup-x86_64.exe -q -P #{packages.join(',')}")
+  plat.install_build_dependencies_with "C:/setup-x86_64.exe -q -P"
+
+  plat.make "/usr/bin/make"
+  plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"
+
+  plat.platform_triple "x86_64-w64-mingw32"
+
+  # Putting these here as a reminder where we use them elsewhere. DO NOT
+  # use the full path, just the name of the executable without the extension.
+  # Otherwise, autoconf gets confused.
+  plat.environment 'CC', "x86_64-w64-mingw32-gcc"
+  plat.environment 'CXX', "x86_64-w64-mingw32-g++"
+
+  plat.make '/usr/bin/make'
+  plat.patch 'TMP=/var/tmp /usr/bin/patch.exe --binary'
+
+  plat.platform_triple 'x86_64-w64-mingw32'
+
+  plat.package_type 'archive'
+  plat.output_dir 'windows'
+end

--- a/configs/projects/pxp-agent.rb
+++ b/configs/projects/pxp-agent.rb
@@ -29,7 +29,7 @@ project 'pxp-agent' do |proj|
   proj.setting(:service_conf, File.join(proj.install_root, 'service_conf'))
   proj.setting(:chocolatey_lib, 'C:/ProgramData/chocolatey/lib') if platform.is_windows?
 
-  proj.component 'pl-cmake-patch'
+  proj.component 'pl-cmake-patch' unless platform.is_windows?
   proj.component 'puppet-runtime'
   proj.component 'runtime' if platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/ || !platform.is_linux?
 

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,1 @@
+C:\setup-x86_64.exe -q -P ruby,ruby-devel,gcc-core,make,git,libyaml-devel

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -12,8 +12,10 @@ namespace :vox do
     abort 'You must provide a platform.' if args[:platform].nil? || args[:platform].empty?
     platform = args[:platform]
 
-    engine = platform =~ /^osx-/ ? 'local' : 'docker'
+    engine = platform =~ /^(osx|windows)-/ ? 'local' : 'docker'
     cmd = "bundle exec build #{project} #{platform} --engine #{engine}"
+
+    FileUtils.rm_rf('C:/ProgramFiles64Folder') if platform =~ /^windows-/
 
     puts "Running #{cmd}"
     exitcode = nil


### PR DESCRIPTION
This uses the MinGW/Cygwin toolchain. In order to avoid having to install the MSBuild toolchain just for nssm that hasn't changed in forever, we simply use a precompiled binary now.

This doesn't actually work yet, and I've decided to just not package pxp-agent with the OpenVox Windows build for now, since it is unused and we were only doing so for the execution_wrapper piece, which will soon be replaced.  But I'm pulling in these changes in case we need to pick it up in the future.