### PR TITLE
Fixes for MacOS 15.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/BlockLength:
 Metrics/BlockNesting:
   Enabled: false
 
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
 Naming/FileName:
   Exclude:
     - 'configs/**/*'

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 require 'open3'
 
-RED = "\033[31m"
-GREEN = "\033[32m"
-RESET = "\033[0m"
+RED = "\033[31m".freeze
+GREEN = "\033[32m".freeze
+RESET = "\033[0m".freeze
 
 def run_command(cmd, silent: true, print_command: false, report_status: false)
   puts "#{GREEN}Running #{cmd}#{RESET}" if print_command

--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -12,7 +12,7 @@ component 'cpp-hocon' do |pkg, settings, platform|
     toolchain = ''
     cmake = '/usr/local/bin/cmake'
     boost_static_flag = '-DBOOST_STATIC=OFF'
-    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
+    special_flags = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     if platform.is_cross_compiled?
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -29,7 +29,7 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
     platform_flags = '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-bbigtoc"'
   elsif platform.is_macos?
     cmake = '/usr/local/bin/cmake'
-    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-enum-constexpr-conversion' -DENABLE_CXX_WERROR=OFF"
+    special_flags = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-enum-constexpr-conversion' -DENABLE_CXX_WERROR=OFF"
     toolchain = ''
     boost_static_flag = '-DBOOST_STATIC=OFF'
     if platform.is_cross_compiled?

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -42,7 +42,7 @@ component 'leatherman' do |pkg, settings, platform|
     toolchain = ''
     cmake = '/usr/local/bin/cmake'
     boost_static_flag = '-DBOOST_STATIC=OFF'
-    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-enum-constexpr-conversion -Wno-deprecated-declarations' -DENABLE_CXX_WERROR=OFF -DLEATHERMAN_MOCK_CURL=FALSE"
+    special_flags = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-enum-constexpr-conversion -Wno-deprecated-declarations' -DENABLE_CXX_WERROR=OFF -DLEATHERMAN_MOCK_CURL=FALSE"
     if platform.is_cross_compiled?
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -34,7 +34,7 @@ component 'pxp-agent' do |pkg, settings, platform|
   elsif platform.is_macos?
     cmake = '/usr/local/bin/cmake'
     toolchain = ''
-    special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-enum-constexpr-conversion' -DENABLE_CXX_WERROR=OFF"
+    special_flags += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-enum-constexpr-conversion' -DENABLE_CXX_WERROR=OFF"
     boost_static_flag = '-DBOOST_STATIC=OFF'
     if platform.is_cross_compiled?
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/


### PR DESCRIPTION
On 15.4, it seems that /private got more restrictive with SIP, and disallows setting a whole bunch of metadata. Since we end up just creating a /private/etc/puppetlabs with nothing in it, this just uses -k flag instead of -ka with rsync. Also, since we usually don't end up putting anything in /var, allow that not to be present in the tarball.

Additionally, the version of CMake in 15.4 does not allow the minimum CMake version to be declared in a Makefile to be anything less than 3.5, and some of them have 3.4 declared. This adds a flag to override what's found in the Makefile to declare 3.5 to be the minimum. It doesn't matter that much because the version of CMake we are using is 4.x.